### PR TITLE
fix pendulum example and better varnames in hamiltonian problem

### DIFF
--- a/examples/pendulum.jl
+++ b/examples/pendulum.jl
@@ -25,8 +25,8 @@ l = 1.
 params = [g,m,l]
 u0 = [1.0,1.0]
 
-prob = ODEProblem(pendulum, u0, (0., 100.), params)
-sol1 = solve(prob, AutoVern7(Rodas5()), dt = .05)
+prob1 = ODEProblem(pendulum, u0, (0., 100.), params)
+sol1 = solve(prob1, AutoVern7(Rodas5()), dt = .05)
 
 #==========================================================#
 
@@ -34,7 +34,7 @@ sol1 = solve(prob, AutoVern7(Rodas5()), dt = .05)
 
 #Solving the simple pendulum with the DiffEqPhysics.jl HamiltonianProblem()
 #==========================================================#
-function H(θ, ℒ, params)
+function H(ℒ, θ, params)
     g = params[1] #gravitational acceleration
     m = params[2] #mass
     l = params[3] #length
@@ -49,13 +49,13 @@ params = [g,m,l]
 θ₀ = 1.
 ℒ₀ = 1.
 
-prob = HamiltonianProblem(H, θ₀, ℒ₀, (0., 100.), p=params)
-sol2 = solve(prob, SofSpa10(), dt = .05);
+prob2 = HamiltonianProblem(H, ℒ₀, θ₀, (0., 100.), p=params)
+sol2 = solve(prob2, SofSpa10(), dt = .05);
 #==========================================================#
 
 
 #Plotting
 #==========================================================#
 plot(sol1, vars=1, tspan=(0,20), label="ODE Method")
-plot!(sol2.t, sol2[1,:], xlim=(0,20), label="Hamiltonian Method")
+plot!(sol2.t, sol2[2,:], xlim=(0,20), label="Hamiltonian Method")
 #They produce the same solution!

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -1,8 +1,8 @@
 struct HamiltonianProblem{iip} <: DiffEqBase.AbstractDynamicalODEProblem end
 
-function HamiltonianProblem(H,p0,q0,tspan,p=nothing;kwargs...)
+function HamiltonianProblem(H, p0, q0, tspan, param=nothing; kwargs...)
   iip = (typeof(q0) <: AbstractArray) && !(typeof(q0) <: SArray)
-  HamiltonianProblem{iip}(H,p0,q0,tspan,p;kwargs...)
+  HamiltonianProblem{iip}(H, p0, q0, tspan, param; kwargs...)
 end
 
 struct PhysicsTag end
@@ -15,26 +15,26 @@ function generic_derivative(q0::Number, hami, x)
     ForwardDiff.derivative(hami, x)
 end
 
-function HamiltonianProblem{false}(H,p0,q0,tspan,p=nothing;kwargs...)
-    dp = function (v,x,p,t)
-        generic_derivative(q0, x->-H(v, x, p), x)
+function HamiltonianProblem{false}(H, p0, q0, tspan, param=nothing; kwargs...)
+    dp = function (p, q, param, t)
+        generic_derivative(q0, q -> -H(p, q, param), q)
     end
-    dq = function (v,x,p,t)
-        generic_derivative(q0, v->H(v, x, p), v)
+    dq = function (p, q, param, t)
+        generic_derivative(q0, p -> H(p, q, param), p)
     end
-    return ODEProblem(DynamicalODEFunction{false}(dp,dq), ArrayPartition(p0,q0), tspan, p; kwargs...)
+    return ODEProblem(DynamicalODEFunction{false}(dp, dq), ArrayPartition(p0, q0), tspan, param; kwargs...)
 end
 
-function HamiltonianProblem{true}(H,p0,q0,tspan,p=nothing;kwargs...)
+function HamiltonianProblem{true}(H, p0, q0, tspan, param=nothing; kwargs...)
     let cfg = ForwardDiff.GradientConfig(PhysicsTag(), p0), cfg2 = ForwardDiff.GradientConfig(PhysicsTag(), q0)
-        dp = function (dv,v,x,p,t)
-            fun2 = x->-H(v, x, p)
-            ForwardDiff.gradient!(dv, fun2, x, cfg2, Val{false}())
+        dp = function (dv, p, q, param, t)
+            fun2 = q -> -H(p, q, param)
+            ForwardDiff.gradient!(dv, fun2, q, cfg2, Val{false}())
         end
-        dq = function (dx,v,x,p,t)
-            fun1 = v-> H(v, x, p)
-            ForwardDiff.gradient!(dx, fun1, v, cfg, Val{false}())
+        dq = function (dx, p, q, param, t)
+            fun1 = p-> H(p, q, param)
+            ForwardDiff.gradient!(dx, fun1, p, cfg, Val{false}())
         end
-        return ODEProblem(DynamicalODEFunction{true}(dp,dq), ArrayPartition(p0,q0), tspan, p; kwargs...)
+        return ODEProblem(DynamicalODEFunction{true}(dp, dq), ArrayPartition(p0, q0), tspan, param; kwargs...)
     end
 end


### PR DESCRIPTION
In the pendulum example, the order of p and q in the definition of `H` was interchanged.
That led to a sign error in the solution (start value of L seemed to be negative in the plot).
The definition of `HamiltonianProblem` assumes the canonical order of arguments (first impulse, then coordinate).

Additionally in this function, the local variable names `x` and `v` were used, where `q` and `p` were meant.
So I propose to change that also.
Fixes part of #50