### PR TITLE
tuple of part derivs  for Hamiltonian

### DIFF
--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -1,7 +1,35 @@
 struct HamiltonianProblem{iip} <: DiffEqBase.AbstractDynamicalODEProblem end
 
-function HamiltonianProblem(H, p0, q0, tspan, param=nothing; kwargs...)
-  iip = (typeof(q0) <: AbstractArray) && !(typeof(q0) <: SArray)
+"""
+    HamiltonianProblem(H, p0, q0, tspan, param=nothing; kwargs...)
+    HamiltonianProblem((dp, dq), p0, q0, tspan, param=nothing; kwargs...)
+
+Define a physical system by its Hamiltonian function `H(p, q, param)` or the function pair
+`dp = -∂H/∂q` and `dq = ∂H/∂p`.
+
+The equations of motion are then given by `q̇ = ∂H/∂p = dq` and `ṗ  = -∂H/∂q = dp`.
+
+The initial values for canonical impulses `p0` and coordinates `q0` may be scalars, `SArray`s or
+other `AbstractArray`s. Their type determines the type of functions `dp` and `dq`.
+
+In the first two cases the derivative functions require the signatures
+`dp(p, q, param, t)` and `dq(p, q, param, t)` while
+in the latter case the partial derivatives use mutating signatures
+`dp!(Δp, p, q, param, t)` and `dq!(Δq, p, q, param, t)` with predefined arrays `Δp` and `Δq`.
+
+If the Hamiltonian function is given, `dp` and `dq` are calculated automatically using
+AD (`ForwardDiff`).
+
+
+!!! note
+It is assumed, that `H` does not depend on `t`, while `dp` and `dq` do.
+It is possible to convert a time-dependent problem given by `H(p, q, param, t)` into a
+time-independent one
+by adding coordinates `q₀ = t` and `p₀ = E` with the new function
+`H([t,p], [E,q], params) := H(p, q, params, t) + E`. 
+"""
+function HamiltonianProblem(H, p0::T, q0::T, tspan, param=nothing; kwargs...) where T
+  iip = T <: AbstractArray && !(T <: SArray)
   HamiltonianProblem{iip}(H, p0, q0, tspan, param; kwargs...)
 end
 
@@ -15,6 +43,13 @@ function generic_derivative(q0::Number, hami, x)
     ForwardDiff.derivative(hami, x)
 end
 
+function HamiltonianProblem{false}((dp, dq)::Tuple{Any,Any}, p0, q0, tspan, param=nothing; kwargs...)
+    return ODEProblem(DynamicalODEFunction{false}(dp, dq), ArrayPartition(p0, q0), tspan, param; kwargs...)
+end
+function HamiltonianProblem{true}((dp, dq)::Tuple{Any,Any}, p0, q0, tspan, param=nothing; kwargs...)
+    return ODEProblem(DynamicalODEFunction{true}(dp, dq), ArrayPartition(p0, q0), tspan, param; kwargs...)
+end
+
 function HamiltonianProblem{false}(H, p0, q0, tspan, param=nothing; kwargs...)
     dp = function (p, q, param, t)
         generic_derivative(q0, q -> -H(p, q, param), q)
@@ -22,19 +57,19 @@ function HamiltonianProblem{false}(H, p0, q0, tspan, param=nothing; kwargs...)
     dq = function (p, q, param, t)
         generic_derivative(q0, p -> H(p, q, param), p)
     end
-    return ODEProblem(DynamicalODEFunction{false}(dp, dq), ArrayPartition(p0, q0), tspan, param; kwargs...)
+    return HamiltonianProblem{false}((dp, dq), p0, q0, tspan, param; kwargs...)
 end
 
 function HamiltonianProblem{true}(H, p0, q0, tspan, param=nothing; kwargs...)
     let cfg = ForwardDiff.GradientConfig(PhysicsTag(), p0), cfg2 = ForwardDiff.GradientConfig(PhysicsTag(), q0)
-        dp = function (dv, p, q, param, t)
+        dp = function (Δp, p, q, param, t)
             fun2 = q -> -H(p, q, param)
-            ForwardDiff.gradient!(dv, fun2, q, cfg2, Val{false}())
+            ForwardDiff.gradient!(Δp, fun2, q, cfg2, Val{false}())
         end
-        dq = function (dx, p, q, param, t)
+        dq = function (Δq, p, q, param, t)
             fun1 = p-> H(p, q, param)
-            ForwardDiff.gradient!(dx, fun1, p, cfg, Val{false}())
+            ForwardDiff.gradient!(Δq, fun1, p, cfg, Val{false}())
         end
-        return ODEProblem(DynamicalODEFunction{true}(dp, dq), ArrayPartition(p0, q0), tspan, param; kwargs...)
+        return HamiltonianProblem{true}((dp, dq), p0, q0, tspan, param; kwargs...)
     end
 end


### PR DESCRIPTION
It happens occasionally, that AD cannot construct the partial derivatives of a given Hamiltonian function `H`.
In this case, as a fall back, the user can calculate the derivatives manually and use the functions to define the problem.

Example:
```
H(p, q, par) = p^2 / 2par.m  - par.m * par.G / norm(q)

p0 =  @SVector [0.0, 1, 0]
q0 = @SVector [1.0, 0, 0]

dp(p, q, par, t) = - par.m * par.G / norm(q)^3 * q
dq(p, q, par, t) = p / par.m

HamiltonianProblem(H, p0, q0, tspan, par)
is equivalent to
Hamiltionian((dp, dq),  p0, q0, tspan, par)
```