### PR TITLE
support time-dependant Hamiltionians

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.jl.*.cov
 *.jl.mem
 Manifest.toml
+.vscode

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-DiffEqBase = "6.5"
+DiffEqBase = "6"
 DiffEqCallbacks = "2.9"
 ForwardDiff = "0.10"
 RecipesBase = "0.7, 0.8, 1.0"

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -49,11 +49,11 @@ end
 
 function HamiltonianProblem{false}(H, p0, q0, tspan, param=nothing; kwargs...)
     if DiffEqBase.numargs(H) == 4
-        dp(p, q, param, t) = generic_derivative(q0, q -> -H(p, q, param, t), q)
-        dq(p, q, param, t) = generic_derivative(q0, p -> H(p, q, param, t), p)
+        dp = (p, q, param, t) -> generic_derivative(q0, q -> -H(p, q, param, t), q)
+        dq = (p, q, param, t) -> generic_derivative(q0, p -> H(p, q, param, t), p)
     else
-        dp(p, q, param, t) = generic_derivative(q0, q -> -H(p, q, param), q)
-        dq(p, q, param, t) = generic_derivative(q0, p -> H(p, q, param), p)
+        dp = (p, q, param, t) -> generic_derivative(q0, q -> -H(p, q, param), q)
+        dq = (p, q, param, t) -> generic_derivative(q0, p -> H(p, q, param), p)
     end
     return HamiltonianProblem{false}((dp, dq), p0, q0, tspan, param; kwargs...)
 end
@@ -64,11 +64,11 @@ function HamiltonianProblem{true}(H, p0, q0, tspan, param=nothing; kwargs...)
         vfalse = Val(false)
         
         if DiffEqBase.numargs(H) == 4
-            dp(Δp, p, q, param, t) = ForwardDiff.gradient!(Δp, q->-H(p, q, param, t), q, cq, vfalse)
-            dq(Δq, p, q, param, t) = ForwardDiff.gradient!(Δq, p-> H(p, q, param, t), p, cp, vfalse)
+            dp = (Δp, p, q, param, t) -> ForwardDiff.gradient!(Δp, q->-H(p, q, param, t), q, cq, vfalse)
+            dq = (Δq, p, q, param, t) -> ForwardDiff.gradient!(Δq, p-> H(p, q, param, t), p, cp, vfalse)
         else
-            dp(Δp, p, q, param, t) = ForwardDiff.gradient!(Δp, q->-H(p, q, param), q, cq, vfalse)
-            dq(Δq, p, q, param, t) = ForwardDiff.gradient!(Δq, p-> H(p, q, param), p, cp, vfalse)
+            dp = (Δp, p, q, param, t) -> ForwardDiff.gradient!(Δp, q->-H(p, q, param), q, cq, vfalse)
+            dq = (Δq, p, q, param, t) -> ForwardDiff.gradient!(Δq, p-> H(p, q, param), p, cp, vfalse)
         end
         return HamiltonianProblem{true}((dp, dq), p0, q0, tspan, param; kwargs...)
     end

--- a/test/hamiltonian_test.jl
+++ b/test/hamiltonian_test.jl
@@ -19,14 +19,14 @@ end
 
 p0 = @SVector rand(2)
 q0 = @SVector rand(2)
-H(dθ, θ, p) = dθ[1] / 2 + dθ[2] / 2 - 9.8 * cos(θ[1]) - 9.8 * cos(θ[2])
+H4(dθ, θ, p, t) = dθ[1] / 2 + dθ[2] / 2 - 9.8 * cos(θ[1]) - 9.8 * cos(θ[2]) + t
 dq(dθ, θ, p, t) = @SVector [0.5, 0.5]
 dp(dθ, θ, p, t) = @SVector [-9.8 * sin(θ[1]), -9.8 * sin(θ[2])]
-acc      = (v, x, p, t) -> ForwardDiff.gradient(x -> -H(v, x, p), x)
-vel      = (v, x, p, t) -> ForwardDiff.gradient(v -> H(v, x, p), v)
+acc      = (v, x, p, t) -> ForwardDiff.gradient(x -> -H4(v, x, p, t), x)
+vel      = (v, x, p, t) -> ForwardDiff.gradient(v -> H4(v, x, p, t), v)
 prob_2   = DynamicalODEProblem(acc, vel, p0, q0, (0., 10.))
 
-@testset "prob2($h)" for h in (H, (dp, dq))
+@testset "prob2($h)" for h in (H4, (dp, dq))
     prob2    = HamiltonianProblem(h, p0, q0, (0., 10.))
     @test test_solve(prob2, prob_2)
 end
@@ -42,4 +42,17 @@ prob_3 = DynamicalODEProblem(acc, vel, p0, q0, (0., 10.))
 @testset "prob3($h)" for h in (H, (dp, dq))
     prob3  = HamiltonianProblem(h, p0, q0, (0., 10.))
     @test test_solve(prob3, prob_3)
+end
+
+H4(dθ, θ, p, t) = (dθ / 2 - 9.8 * cos.(θ))[1] + t
+p0, q0 = [rand(5) for i in 1:2]
+dq(dx, dΘ, θ, p, t) = (dx .= [0.5, 0, 0, 0, 0])
+dp(dv, dθ, θ, p, t) = (dv .= [(-9.8 * sin.(θ))[1], 0, 0, 0, 0])
+acc = (dv, v, x, p, t) -> ForwardDiff.gradient!(dv, x -> -H4(v, x, p, t), x)
+vel = (dx, v, x, p, t) -> ForwardDiff.gradient!(dx, v -> H4(v, x, p, t), v)
+prob_4 = DynamicalODEProblem(acc, vel, p0, q0, (0., 10.))
+
+@testset "prob4($h)" for h in (H4, (dp, dq))
+    prob4  = HamiltonianProblem(h, p0, q0, (0., 10.))
+    @test test_solve(prob4, prob_4)
 end

--- a/test/hamiltonian_test.jl
+++ b/test/hamiltonian_test.jl
@@ -2,7 +2,7 @@ using Test
 using DiffEqPhysics, ForwardDiff, OrdinaryDiffEq
 using StaticArrays, LinearAlgebra, Random
 
-test_solve(prob...) = mapreduce(p->solve(p, VelocityVerlet(), dt=1//2).u, ==, prob)
+test_solve(prob...) = mapreduce(p->solve(p, Tsit5(), dt=1//2).u, ==, prob)
 
 p0, q0   = rand(2)
 H(dθ, θ, p) = dθ / 2 - 9.8 * cos(θ)


### PR DESCRIPTION
The old API restricts the Hamiltonian function to signature `H(p, q, param)`, while the mechanism can handle time dependant equations of motion well.

This PR allows for functions with signature `H(p, q, param, t)`.