### PR TITLE
changed default param argument to `NullParameters()`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqPhysics"
 uuid = "055956cb-9e8b-5191-98cc-73ae4a59e68a"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "3.9.0"
+version = "3.9.1"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/src/DiffEqPhysics.jl
+++ b/src/DiffEqPhysics.jl
@@ -5,6 +5,8 @@ using Reexport
 using ForwardDiff, StaticArrays, RecipesBase
 using Random, Printf, LinearAlgebra
 
+using DiffEqBase: NullParameters
+
 include("hamiltonian.jl")
 include("plot.jl")
 

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -25,7 +25,7 @@ AD (`ForwardDiff`).
 `H` may be defined with or without time as fourth argument. If both methods are defined,
 that with 4 arguments is used.
 """
-function HamiltonianProblem(H, p0::S, q0::T, tspan, param=nothing; kwargs...) where {S,T}
+function HamiltonianProblem(H, p0::S, q0::T, tspan, param=NullParameters(); kwargs...) where {S,T}
   iip = T <: AbstractArray && !(T <: SArray) && S <: AbstractArray && !(S <: SArray)
   HamiltonianProblem{iip}(H, p0, q0, tspan, param; kwargs...)
 end
@@ -40,14 +40,14 @@ function generic_derivative(q0::Number, hami, x)
     ForwardDiff.derivative(hami, x)
 end
 
-function HamiltonianProblem{false}((dp, dq)::Tuple{Any,Any}, p0, q0, tspan, param=nothing; kwargs...)
+function HamiltonianProblem{false}((dp, dq)::Tuple{Any,Any}, p0, q0, tspan, param=NullParameters(); kwargs...)
     return ODEProblem(DynamicalODEFunction{false}(dp, dq), ArrayPartition(p0, q0), tspan, param; kwargs...)
 end
-function HamiltonianProblem{true}((dp, dq)::Tuple{Any,Any}, p0, q0, tspan, param=nothing; kwargs...)
+function HamiltonianProblem{true}((dp, dq)::Tuple{Any,Any}, p0, q0, tspan, param=NullParameters(); kwargs...)
     return ODEProblem(DynamicalODEFunction{true}(dp, dq), ArrayPartition(p0, q0), tspan, param; kwargs...)
 end
 
-function HamiltonianProblem{false}(H, p0, q0, tspan, param=nothing; kwargs...)
+function HamiltonianProblem{false}(H, p0, q0, tspan, param=NullParameters(); kwargs...)
     if DiffEqBase.numargs(H) == 4
         dp = (p, q, param, t) -> generic_derivative(q0, q -> -H(p, q, param, t), q)
         dq = (p, q, param, t) -> generic_derivative(q0, p -> H(p, q, param, t), p)
@@ -59,7 +59,7 @@ function HamiltonianProblem{false}(H, p0, q0, tspan, param=nothing; kwargs...)
     return HamiltonianProblem{false}((dp, dq), p0, q0, tspan, param; kwargs...)
 end
 
-function HamiltonianProblem{true}(H, p0, q0, tspan, param=nothing; kwargs...)
+function HamiltonianProblem{true}(H, p0, q0, tspan, param=NullParameters(); kwargs...)
     let cp = ForwardDiff.GradientConfig(PhysicsTag(), p0),
         cq = ForwardDiff.GradientConfig(PhysicsTag(), q0),
         vfalse = Val(false)


### PR DESCRIPTION
Some packages (in my case DiffEqGPU.jl) seem to assume that if no parameter arguments are given, the parameter type is `NullParameters`.  Actually, I'm a little unclear about what exactly is permitted here since DiffEqGPU calls `Array(prob.p)`, which should probably be changed anyway since this throws errors at all sorts of things.

Regardless, this change seemed appropriate and fixes that particular issue.