### PR TITLE
Fixed the double pendulum example

### DIFF
--- a/examples/double_pendulum.jl
+++ b/examples/double_pendulum.jl
@@ -74,7 +74,7 @@ params = [l1, l2, m1, m2, g]
 q0 = [1.0,1.0]
 p0 = [1.0,1.0]
 times = (0.,25.)
-prob = HamiltonianProblem(H, q0, p0, times, params)
+prob = HamiltonianProblem(H, p0, q0, times, params)
 sol2 = solve(prob, SofSpa10(), dt = .05)
 
 plot(sol2, vars=1, xlim=(0,20), label="Momentum1")


### PR DESCRIPTION
Prior to this fix the double pendulum example lists `p0` and `q0` in the wrong order. This doesn't cause the functionality to fail as `p0=q0` in the example, but it does cause it to be misleading, as someone looking at the example (like myself) can accidentally end up using the wrong way when they write code based on this example code.

## Checklist

- [x] Appropriate tests were added - no tests were needed
- [x] Any code changes were done in a way that does not break public API - this is not a public API and makes no change to the actual code
- [x] All documentation related to code changes were updated - this change makes the example match the actual functionality
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC). - Didn't check this but I changed two letters so hopefully it's fine
- [x] Any new documentation only uses public API - no new documentation
  
## Additional context

This caused an issue when working on my graduate mechanics homework :(
