### PR TITLE
Documentation improvements: README overhaul, fix deprecated example, add docstrings

### DIFF
--- a/examples/double_pendulum.jl
+++ b/examples/double_pendulum.jl
@@ -49,7 +49,7 @@ plot!(sol1, vars = 4, xlim = (0, 20), label = "theta2")#========================
 
 #Now with HamiltonianProblem()
 
-function H(p, θ, params)
+function H(p, θ, params, t)
     l1 = params[1]
     l2 = params[2]
     m1 = params[3]

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -1,3 +1,6 @@
+"""
+Internal type for orbit plotting recipe.
+"""
 struct OrbitPlot
     sol::Any
     body_names::Any
@@ -21,12 +24,42 @@ end
     end
 end
 
+"""
+    orbitplot(sol; body_names=nothing, dim=3, kwargs...)
+
+Plot the orbits from an N-body simulation solution using Plots.jl recipes.
+
+# Arguments
+- `sol`: A `DESolution` from solving an N-body problem
+- `body_names`: Optional vector of names for each body (defaults to "orbit 1", "orbit 2", etc.)
+- `dim`: Dimension of the plot, either `2` or `3` (default: `3`)
+- `kwargs...`: Additional keyword arguments passed to the plot recipe
+
+# Returns
+A plot object showing the trajectories of all bodies.
+"""
 function orbitplot(sol::DESolution; body_names = nothing, dim = 3, kwargs...)
     RecipesBase.plot(OrbitPlot(sol, body_names, dim); kwargs...)
 end
 
 export orbitplot
 
+"""
+    plot_orbits(sol; body_names=nothing, dim=3, kwargs...)
+
+Plot the orbits from an N-body simulation solution.
+
+# Arguments
+- `sol`: A solution from solving an N-body problem
+- `body_names`: Optional vector of names for each body (defaults to "orbit 1", "orbit 2", etc.)
+- `dim`: Dimension of the plot, either `2` or `3` (default: `3`)
+- `kwargs...`: Additional keyword arguments passed to `plot`
+
+# Returns
+A plot object showing the trajectories of all bodies.
+
+See also: [`orbitplot`](@ref)
+"""
 function plot_orbits(sol; body_names = nothing, dim = 3, kwargs...)
     @assert dim ∈ (2, 3)
     N = length(sol.u[1].x[1].x[1])


### PR DESCRIPTION
## Summary

- Completely rewrote README.md with practical usage examples and clear documentation
- Fixed deprecated Hamiltonian signature in double_pendulum.jl example
- Added docstrings to orbitplot and plot_orbits functions

## Changes

### README.md
- Replaced outdated Gitter badge with Zulip (current SciML community chat)
- Added package description explaining what DiffEqPhysics.jl provides
- Added installation instructions
- Added quick start example with a simple pendulum demonstrating the main API
- Documented key features (AD, multiple input types, symplectic solvers, manual derivatives)
- Added section showing how to provide manual derivative functions for better performance
- Removed commented-out NBody section (functionality now in NBodySimulator.jl)
- Added reference to the examples folder

### examples/double_pendulum.jl
- Updated `H(p, θ, params)` to `H(p, θ, params, t)` to use the current non-deprecated API

### src/plot.jl
- Added docstrings for `orbitplot` and `plot_orbits` functions
- Added brief docstring for internal `OrbitPlot` type

## Testing

- All package tests pass
- Verified README examples run correctly

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)