### PR TITLE
Improve explicit imports hygiene

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,15 +1,12 @@
 name = "DiffEqPhysics"
 uuid = "055956cb-9e8b-5191-98cc-73ae4a59e68a"
-authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 version = "3.15.1"
+authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
@@ -19,6 +16,7 @@ StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 [compat]
 DiffEqBase = "6"
 DiffEqCallbacks = "2.9, 3, 4"
+ExplicitImports = "1"
 ForwardDiff = "0.10, 1"
 RecipesBase = "0.7, 0.8, 1.0"
 RecursiveArrayTools = "1,2, 3"
@@ -28,10 +26,13 @@ StaticArraysCore = "1.4"
 julia = "1.6"
 
 [extras]
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "OrdinaryDiffEq", "SafeTestsets", "StaticArrays"]
+test = ["ExplicitImports", "LinearAlgebra", "OrdinaryDiffEq", "Random", "SafeTestsets", "StaticArrays", "Test"]

--- a/src/DiffEqPhysics.jl
+++ b/src/DiffEqPhysics.jl
@@ -1,11 +1,15 @@
 module DiffEqPhysics
 
-using Reexport
+using Reexport: @reexport
+using DiffEqBase: DiffEqBase
+using RecursiveArrayTools: RecursiveArrayTools, ArrayPartition
 @reexport using DiffEqBase, RecursiveArrayTools
-using ForwardDiff, StaticArraysCore, RecipesBase
-using Random, Printf, LinearAlgebra
-
-using DiffEqBase: NullParameters
+using ForwardDiff: ForwardDiff
+using StaticArraysCore: StaticArraysCore
+using RecipesBase: RecipesBase, @recipe, @series
+using SciMLBase: SciMLBase, NullParameters, ODEProblem, DynamicalODEFunction,
+                 isinplace, AbstractDynamicalODEProblem, numargs, DESolution,
+                 TooManyArgumentsError, TooFewArgumentsError, FunctionArgumentsError
 
 include("hamiltonian.jl")
 include("plot.jl")

--- a/src/hamiltonian.jl
+++ b/src/hamiltonian.jl
@@ -63,7 +63,7 @@ function Base.showerror(io::IO, e::HamiltonainFunctionArgumentsError)
     println(io, methods(e.f))
 end
 
-struct HamiltonianProblem{iip} <: DiffEqBase.AbstractDynamicalODEProblem end
+struct HamiltonianProblem{iip} <: AbstractDynamicalODEProblem end
 
 """
     HamiltonianProblem(H, p0, q0, tspan, param=nothing; kwargs...)
@@ -123,16 +123,16 @@ function HamiltonianProblem{false}(H, p0, q0, tspan, param = NullParameters(); k
     try
         isinplace(H, 4)
     catch e
-        if e isa SciMLBase.TooManyArgumentsError
+        if e isa TooManyArgumentsError
             throw(HamiltonainTooManyArgumentsError(e.fname, e.f))
-        elseif e isa SciMLBase.TooFewArgumentsError
+        elseif e isa TooFewArgumentsError
             throw(HamiltonainTooFewArgumentsError(e.fname, e.f))
-        elseif e isa SciMLBase.FunctionArgumentsError
+        elseif e isa FunctionArgumentsError
             throw(HamiltonainFunctionArgumentsError(e.fname, e.f))
         end
     end
 
-    if 4 in DiffEqBase.numargs(H)
+    if 4 in numargs(H)
         dp = (p, q, param, t) -> generic_derivative(q0, q -> -H(p, q, param, t), q)
         dq = (p, q, param, t) -> generic_derivative(q0, p -> H(p, q, param, t), p)
     else
@@ -147,18 +147,18 @@ function HamiltonianProblem{true}(H, p0, q0, tspan, param = NullParameters(); kw
     try
         isinplace(H, 4)
     catch e
-        if e isa SciMLBase.TooManyArgumentsError
+        if e isa TooManyArgumentsError
             throw(HamiltonainTooManyArgumentsError(e.fname, e.f))
-        elseif e isa SciMLBase.TooFewArgumentsError
+        elseif e isa TooFewArgumentsError
             throw(HamiltonainTooFewArgumentsError(e.fname, e.f))
-        elseif e isa SciMLBase.FunctionArgumentsError
+        elseif e isa FunctionArgumentsError
             throw(HamiltonainFunctionArgumentsError(e.fname, e.f))
         end
     end
     let cp = ForwardDiff.GradientConfig(PhysicsTag(), p0),
         cq = ForwardDiff.GradientConfig(PhysicsTag(), q0), vfalse = Val(false)
 
-        if 4 in DiffEqBase.numargs(H)
+        if 4 in numargs(H)
             dp = (Δp, p, q, param,
                 t) -> ForwardDiff.gradient!(Δp, q->-H(p, q, param, t), q, cq, vfalse)
             dq = (Δq, p, q, param,

--- a/test/explicit_imports.jl
+++ b/test/explicit_imports.jl
@@ -1,0 +1,8 @@
+using ExplicitImports
+using DiffEqPhysics
+using Test
+
+@testset "ExplicitImports" begin
+    @test check_no_implicit_imports(DiffEqPhysics) === nothing
+    @test check_no_stale_explicit_imports(DiffEqPhysics) === nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,3 +6,7 @@ using SafeTestsets, Test
     include("hamiltonian_test.jl")
 end
 #@safetestset "N-Body Test" begin include("nbody_test.jl") end
+
+@safetestset "Explicit Imports" begin
+    include("explicit_imports.jl")
+end


### PR DESCRIPTION
## Summary

This PR improves import hygiene in DiffEqPhysics.jl based on ExplicitImports.jl analysis:

- Add explicit imports from SciMLBase for types used in the package (NullParameters, ODEProblem, DynamicalODEFunction, isinplace, AbstractDynamicalODEProblem, numargs, DESolution, TooManyArgumentsError, TooFewArgumentsError, FunctionArgumentsError)
- Import module bindings explicitly (DiffEqBase, RecursiveArrayTools) to satisfy ExplicitImports check
- Replace qualified references with direct imports (e.g., `numargs` instead of `DiffEqBase.numargs`, `AbstractDynamicalODEProblem` instead of `DiffEqBase.AbstractDynamicalODEProblem`)
- Remove unused stdlib deps from main deps (Random, Printf, LinearAlgebra) - these were imported but never used in the package
- Move LinearAlgebra and Random to test extras (needed by test files)
- Add ExplicitImports.jl test to CI to maintain import hygiene going forward

### Files Changed
- `src/DiffEqPhysics.jl`: Updated import statements for explicit imports
- `src/hamiltonian.jl`: Replaced qualified references with direct imports
- `Project.toml`: Removed unused deps, added ExplicitImports to test dependencies
- `test/runtests.jl`: Added ExplicitImports testset
- `test/explicit_imports.jl`: New test file for ExplicitImports checks

## Test plan
- [x] All existing tests pass
- [x] ExplicitImports checks pass (`check_no_implicit_imports` and `check_no_stale_explicit_imports`)

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)