### PR TITLE
Update RecursiveArrayTools compat to support v4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DiffEqPhysics"
 uuid = "055956cb-9e8b-5191-98cc-73ae4a59e68a"
-version = "3.15.1"
+version = "3.16.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
@@ -19,7 +19,7 @@ DiffEqCallbacks = "2.9, 3, 4"
 ExplicitImports = "1"
 ForwardDiff = "0.10, 1"
 RecipesBase = "0.7, 0.8, 1.0"
-RecursiveArrayTools = "1,2, 3"
+RecursiveArrayTools = "1, 2, 3, 4"
 Reexport = "0.2, 1.0"
 SciMLBase = "1.73, 2"
 StaticArraysCore = "1.4"


### PR DESCRIPTION
## Summary
- Bump RecursiveArrayTools compat to include v4
- RecursiveArrayTools v4 makes `AbstractVectorOfArray <: AbstractArray`

## Context
Part of the ecosystem-wide update for RecursiveArrayTools v4. The main breaking change is that `AbstractVectorOfArray` now subtypes `AbstractArray`, changing linear indexing behavior (`A[i]` returns scalar elements instead of inner arrays).

## Notes
- CI will fail until upstream deps (SciMLBase, DiffEqBase, OrdinaryDiffEq) also allow RAT v4
- Code/test changes may be needed for deprecated linear indexing patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)