### PR TITLE
Fix SciMLBase v3 breaking changes and bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DiffEqPhysics"
 uuid = "055956cb-9e8b-5191-98cc-73ae4a59e68a"
-version = "3.16.0"
+version = "3.17.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
@@ -21,7 +21,7 @@ ForwardDiff = "0.10, 1"
 RecipesBase = "0.7, 0.8, 1.0"
 RecursiveArrayTools = "1, 2, 3, 4"
 Reexport = "0.2, 1.0"
-SciMLBase = "1.73, 2"
+SciMLBase = "2, 3"
 StaticArraysCore = "1.4"
 julia = "1.6"
 

--- a/src/DiffEqPhysics.jl
+++ b/src/DiffEqPhysics.jl
@@ -8,7 +8,7 @@ using ForwardDiff: ForwardDiff
 using StaticArraysCore: StaticArraysCore
 using RecipesBase: RecipesBase, @recipe, @series
 using SciMLBase: SciMLBase, NullParameters, ODEProblem, DynamicalODEFunction,
-    isinplace, AbstractDynamicalODEProblem, numargs, DESolution,
+    isinplace, AbstractDynamicalODEProblem, numargs, AbstractODESolution,
     TooManyArgumentsError, TooFewArgumentsError, FunctionArgumentsError
 
 include("hamiltonian.jl")

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -30,7 +30,7 @@ end
 Plot the orbits from an N-body simulation solution using Plots.jl recipes.
 
 # Arguments
-- `sol`: A `DESolution` from solving an N-body problem
+- `sol`: A `SciMLBase.AbstractODESolution` from solving an N-body problem
 - `body_names`: Optional vector of names for each body (defaults to "orbit 1", "orbit 2", etc.)
 - `dim`: Dimension of the plot, either `2` or `3` (default: `3`)
 - `kwargs...`: Additional keyword arguments passed to the plot recipe
@@ -38,7 +38,7 @@ Plot the orbits from an N-body simulation solution using Plots.jl recipes.
 # Returns
 A plot object showing the trajectories of all bodies.
 """
-function orbitplot(sol::DESolution; body_names = nothing, dim = 3, kwargs...)
+function orbitplot(sol::AbstractODESolution; body_names = nothing, dim = 3, kwargs...)
     return RecipesBase.plot(OrbitPlot(sol, body_names, dim); kwargs...)
 end
 

--- a/test/nbody_test.jl
+++ b/test/nbody_test.jl
@@ -42,8 +42,8 @@ using RecursiveArrayTools
 
     # Make sure the distances from the sun stay small enough
     f = (x, y, z, j) -> sqrt((x[1] - x[j])^2 + (y[1] - y[j])^2 + (z[1] - z[j])^2)
-    for i in 1:length(sol)
-        x, y, z = sol[i].x[1].x
+    for i in 1:length(sol.u)
+        x, y, z = sol.u[i].x[1].x
         @test f(x, y, z, 2) < 6
         @test f(x, y, z, 3) < 10.5
         @test f(x, y, z, 4) < 21


### PR DESCRIPTION
## Summary
- Replace removed `DESolution` type alias with `AbstractODESolution` in both the import statement and `orbitplot` function signature
- Fix solution indexing in tests: `sol[i]` → `sol.u[i]` and `length(sol)` → `length(sol.u)` (v3 changed `length(sol)` semantics to total elements, not timesteps)
- Update SciMLBase compat bounds from `"1.73, 2"` to `"2, 3"` (drop v1 support)
- Bump package version from 3.16.0 to 3.17.0
- Supersedes #103

## Test plan
- [ ] `Pkg.test()` passes with SciMLBase v3
- [ ] `orbitplot` dispatches correctly on `AbstractODESolution`
- [ ] N-body test loop iterates over timesteps correctly via `sol.u`

🤖 Generated with [Claude Code](https://claude.com/claude-code)