### PR TITLE
Update for SciMLBase v3 compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ ForwardDiff = "0.10, 1"
 RecipesBase = "0.7, 0.8, 1.0"
 RecursiveArrayTools = "1, 2, 3, 4"
 Reexport = "0.2, 1.0"
-SciMLBase = "1.73, 2"
+SciMLBase = "1.73, 2, 3"
 StaticArraysCore = "1.4"
 julia = "1.6"
 

--- a/src/DiffEqPhysics.jl
+++ b/src/DiffEqPhysics.jl
@@ -8,7 +8,7 @@ using ForwardDiff: ForwardDiff
 using StaticArraysCore: StaticArraysCore
 using RecipesBase: RecipesBase, @recipe, @series
 using SciMLBase: SciMLBase, NullParameters, ODEProblem, DynamicalODEFunction,
-    isinplace, AbstractDynamicalODEProblem, numargs, DESolution,
+    isinplace, AbstractDynamicalODEProblem, numargs, AbstractSciMLSolution,
     TooManyArgumentsError, TooFewArgumentsError, FunctionArgumentsError
 
 include("hamiltonian.jl")

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -30,7 +30,7 @@ end
 Plot the orbits from an N-body simulation solution using Plots.jl recipes.
 
 # Arguments
-- `sol`: A `DESolution` from solving an N-body problem
+- `sol`: A SciML solution from solving an N-body problem
 - `body_names`: Optional vector of names for each body (defaults to "orbit 1", "orbit 2", etc.)
 - `dim`: Dimension of the plot, either `2` or `3` (default: `3`)
 - `kwargs...`: Additional keyword arguments passed to the plot recipe
@@ -38,7 +38,7 @@ Plot the orbits from an N-body simulation solution using Plots.jl recipes.
 # Returns
 A plot object showing the trajectories of all bodies.
 """
-function orbitplot(sol::DESolution; body_names = nothing, dim = 3, kwargs...)
+function orbitplot(sol::AbstractSciMLSolution; body_names = nothing, dim = 3, kwargs...)
     return RecipesBase.plot(OrbitPlot(sol, body_names, dim); kwargs...)
 end
 

--- a/test/nbody_test.jl
+++ b/test/nbody_test.jl
@@ -42,8 +42,8 @@ using RecursiveArrayTools
 
     # Make sure the distances from the sun stay small enough
     f = (x, y, z, j) -> sqrt((x[1] - x[j])^2 + (y[1] - y[j])^2 + (z[1] - z[j])^2)
-    for i in 1:length(sol)
-        x, y, z = sol[i].x[1].x
+    for i in 1:length(sol.u)
+        x, y, z = sol.u[i].x[1].x
         @test f(x, y, z, 2) < 6
         @test f(x, y, z, 3) < 10.5
         @test f(x, y, z, 4) < 21


### PR DESCRIPTION
## Summary
Handles the breaking changes from SciMLBase v3.0 so that DiffEqPhysics.jl can be used on the new major version. Supersedes the dependabot bump in #103 which only updates the compat bound.

## Changes
- Replace the removed `DESolution` import with `AbstractSciMLSolution`. `DESolution` (along with other deprecated aliases `DEAlgorithm`, `DEProblem`, etc.) was removed in SciMLBase v3.
- Update the `orbitplot` method signature (and its docstring) from `sol::DESolution` to `sol::AbstractSciMLSolution`.
- Fix the N-body test. In SciMLBase v3 / RecursiveArrayTools v4, `AbstractVectorOfArray` (and thus `ODESolution`) now subtypes `AbstractArray`, so `sol[i]` returns the i-th scalar element (column-major) rather than the i-th timestep, and `length(sol)` returns total elements rather than timestep count. Use `sol.u[i]` and `length(sol.u)` instead.
- Expand the `SciMLBase` compat bound to `"1.73, 2, 3"`.

## Test plan
- [ ] CI passes on the branch (tests adjusted to the new semantics).
- [ ] Downstream packages that depend on DiffEqPhysics can resolve against SciMLBase v3.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)