### PR TITLE
Bump DiffEqBase compat to include v7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DiffEqPhysics"
 uuid = "055956cb-9e8b-5191-98cc-73ae4a59e68a"
-version = "3.17.0"
+version = "3.18.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
@@ -14,7 +14,7 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 
 [compat]
-DiffEqBase = "6"
+DiffEqBase = "6, 7"
 DiffEqCallbacks = "2.9, 3, 4"
 ExplicitImports = "1"
 ForwardDiff = "0.10, 1"


### PR DESCRIPTION
## Summary

Widen `DiffEqBase = "6"` → `"6, 7"` so DiffEqPhysics resolves alongside `lib/DiffEqBase` v7 (OrdinaryDiffEq v7 release). Bumps 3.17.0 → 3.18.0.

Already-OK: `DiffEqCallbacks = "2.9, 3, 4"`, `RecursiveArrayTools = "1, 2, 3, 4"`, `SciMLBase = "1.73, 2, 3"`.

## Why this is source-level safe

Grepped `src/` clean for every symbol removed in the v7 NEWS / SciMLBase v3 breaking notes.

## Scope

Part of the v7-compat-widening set alongside DiffEqCallbacks#303, DiffEqNoiseProcess#271, DiffEqProblemLibrary#182, JumpProcesses#580, ModelingToolkit#4467, StateSelection#71, ParameterizedFunctions#151, SciMLSensitivity#1431, Sundials#526, ODEInterfaceDiffEq#95, DiffEqFinancial#68.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>