### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
-      - "/test"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -11,22 +11,11 @@ on:
     paths-ignore:
       - 'docs/**'
 jobs:
-  test:
+  downgrade:
     if: false
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+      allow-reresolve: false
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,5 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,5 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts the remaining inline CI workflows to the SciML centralized reusable workflows (pinned `@v1`), with `secrets: "inherit"` on every caller. End-state matches the Sundials.jl pattern.

## Converted (inline -> central)
- `FormatCheck.yml`: `fredrikekre/runic-action` -> `runic.yml@v1`
- `SpellCheck.yml`: `crate-ci/typos` -> `spellcheck.yml@v1`
- `Downgrade.yml`: inline downgrade job -> `downgrade.yml@v1`, preserving `julia-version: 1.10`, `skip: Pkg,TOML`, `allow-reresolve: false`, and the existing `if: false` (kept disabled exactly as before)

## Unchanged
- `Tests.yml`: already a `tests.yml@v1` caller (version matrix 1/lts/pre) and already inherits secrets
- `TagBot.yml`: left as-is

## Other
- `dependabot.yml`: removed the `crate-ci/typos` version-ignore (typos is now pinned in the central spellcheck workflow); trimmed the `julia` ecosystem directories to those that actually contain a `Project.toml` (`/`)
- No `docs/make.jl`, no downstream/benchmark/CompatHelper workflows present, so none added.

## Verification
- Runic ran clean locally (`Runic.main(["--inplace","."])` -> no changes; repo was already Runic-formatted). runic_formatted: false (no changes needed).
- `typos -w .` made 0 changes; `typos .` exits 0.
- All changed YAML validated with `yaml.safe_load`.

## Warning
Check names change (jobs now run as reusable-workflow callers). Branch-protection required status checks will need to be updated to match the new check names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)