### PR TITLE
ci: add standard centralized workflows (auto-format, dependabot-automerge, docs-preview-cleanup)

### DIFF
--- a/.github/workflows/DependabotAutoMerge.yml
+++ b/.github/workflows/DependabotAutoMerge.yml
@@ -1,0 +1,9 @@
+name: "Dependabot Auto-merge"
+on: pull_request
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  automerge:
+    uses: "SciML/.github/.github/workflows/dependabot-automerge.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/RunicSuggestions.yml
+++ b/.github/workflows/RunicSuggestions.yml
@@ -1,0 +1,9 @@
+name: "Runic Suggestions"
+on: pull_request
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  runic-suggestions:
+    uses: "SciML/.github/.github/workflows/runic-suggestions-on-pr.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
This PR adds the missing SciML standard centralized **caller** workflows for this repo:

- `.github/workflows/RunicSuggestions.yml` — Runic auto-format suggestions on PRs (uses `runic-suggestions-on-pr.yml@v1`)
- `.github/workflows/DependabotAutoMerge.yml` — Dependabot auto-merge (uses `dependabot-automerge.yml@v1`)

These are thin caller files that reference the centralized reusable workflows in `SciML/.github` (`@v1`). No existing workflows, `Project.toml`, or source files were modified.

> **Ignore until reviewed by @ChrisRackauckas.** This PR is opened as a draft and should not be merged until reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)