### PR TITLE
QA: run_qa v1.6 form + ExplicitImports

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
-DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
@@ -15,8 +14,6 @@ StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 
 [compat]
 DiffEqBase = "7"
-DiffEqCallbacks = "4.16.0"
-ExplicitImports = "1"
 ForwardDiff = "1.0.1"
 LinearAlgebra = "1"
 OrdinaryDiffEq = "7"
@@ -26,14 +23,13 @@ RecursiveArrayTools = "4"
 Reexport = "1.2.2"
 SafeTestsets = "0.1, 1"
 SciMLBase = "3.1.0"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 StaticArrays = "1"
 StaticArraysCore = "1.4.3"
 Test = "1"
 julia = "1.10"
 
 [extras]
-ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -43,4 +39,4 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ExplicitImports", "LinearAlgebra", "OrdinaryDiffEq", "Random", "SafeTestsets", "SciMLTesting", "StaticArrays", "Test"]
+test = ["LinearAlgebra", "OrdinaryDiffEq", "Random", "SafeTestsets", "SciMLTesting", "StaticArrays", "Test"]

--- a/test/explicit_imports.jl
+++ b/test/explicit_imports.jl
@@ -1,8 +1,0 @@
-using ExplicitImports
-using DiffEqPhysics
-using Test
-
-@testset "ExplicitImports" begin
-    @test check_no_implicit_imports(DiffEqPhysics) === nothing
-    @test check_no_stale_explicit_imports(DiffEqPhysics) === nothing
-end

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,8 +1,6 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 DiffEqPhysics = "055956cb-9e8b-5191-98cc-73ae4a59e68a"
-JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
@@ -11,8 +9,6 @@ DiffEqPhysics = {path = "../.."}
 
 [compat]
 Aqua = "0.8"
-JET = "0.9,0.10,0.11"
-SafeTestsets = "0.1, 1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -8,14 +8,6 @@ run_qa(
             ignore = (
                 :GradientConfig, :derivative, :gradient, :gradient!,  # ForwardDiff: not public
                 :plot,                                                # RecipesBase: not public
-                :depwarn,                                             # Base: not public (Julia 1.10)
-            ),
-        ),
-        all_explicit_imports_are_public = (;
-            ignore = (
-                # SciMLBase: not public (exported/public-declared upstream pending)
-                :AbstractDynamicalODEProblem, :AbstractSciMLSolution, :FunctionArgumentsError,
-                :NullParameters, :TooFewArgumentsError, :TooManyArgumentsError, :numargs,
             ),
         ),
     ),

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,17 +1,33 @@
-using DiffEqPhysics, Aqua, JET, Test
+using SciMLTesting, DiffEqPhysics, Test
 
-@testset "Aqua" begin
-    # stale_deps and deps_compat fail on genuine Project.toml hygiene findings,
-    # marked @test_broken below pending fix; see
-    # https://github.com/SciML/DiffEqPhysics.jl/issues/118
-    Aqua.test_all(DiffEqPhysics; stale_deps = false, deps_compat = false)
-    @test_broken false  # Aqua stale_deps: DiffEqCallbacks declared but unused — see https://github.com/SciML/DiffEqPhysics.jl/issues/118
-    @test_broken false  # Aqua deps_compat: Pkg extra missing a [compat] entry — see https://github.com/SciML/DiffEqPhysics.jl/issues/118
-end
+run_qa(
+    DiffEqPhysics;
+    explicit_imports = true,
+    ei_kwargs = (;
+        all_qualified_accesses_are_public = (;
+            ignore = (
+                :GradientConfig, :derivative, :gradient, :gradient!,  # ForwardDiff: not public
+                :plot,                                                # RecipesBase: not public
+                :depwarn,                                             # Base: not public (Julia 1.10)
+            ),
+        ),
+        all_explicit_imports_are_public = (;
+            ignore = (
+                # SciMLBase: not public (exported/public-declared upstream pending)
+                :AbstractDynamicalODEProblem, :AbstractSciMLSolution, :FunctionArgumentsError,
+                :NullParameters, :TooFewArgumentsError, :TooManyArgumentsError, :numargs,
+            ),
+        ),
+    ),
+)
 
-@testset "JET" begin
-    # JET.test_package reports genuine errors in src/plot.jl (RecipesBase.plot /
-    # DiffEqPhysics.plot not defined); marked @test_broken pending fix, see
-    # https://github.com/SciML/DiffEqPhysics.jl/issues/118
-    @test_broken false  # JET: no matching method `plot(::OrbitPlot)` / `DiffEqPhysics.plot` not defined in src/plot.jl — see https://github.com/SciML/DiffEqPhysics.jl/issues/118
+# JET reports genuine errors in src/plot.jl (RecipesBase.plot has no inferable
+# method for OrbitPlot, and DiffEqPhysics.plot / plot! are undefined in
+# plot_orbits). The finding is JET-analysis-version dependent (JET 0.11 on the
+# `1` lane surfaces it; JET 0.9, the only version installable on the `lts` lane,
+# does not), so it is kept as a static tracked @test_broken rather than run_qa's
+# version-auto-flagging jet_broken (which would Unexpected-Pass on lts and hard-FAIL
+# on `1`). Pending fix, see https://github.com/SciML/DiffEqPhysics.jl/issues/118
+@testset "JET (broken)" begin
+    @test_broken false  # JET: no method `plot(::OrbitPlot)` / `DiffEqPhysics.plot` undefined in src/plot.jl — https://github.com/SciML/DiffEqPhysics.jl/issues/118
 end


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

Brings this repo's QA onto the SciMLTesting 1.6 `run_qa` form with ExplicitImports enabled (converts the hand-rolled Aqua/JET `test/qa/qa.jl`).

## ExplicitImports findings (now enabled, `explicit_imports = true`)

Six checks run. Four pass as-is. The two public-API checks flag only **other packages'** non-public names, all genuinely used (not stale), so they are ignored via `ei_kwargs` with the source package documented:

| Check | Ignored names | Source pkg |
|---|---|---|
| `all_qualified_accesses_are_public` | `GradientConfig`, `derivative`, `gradient`, `gradient!` | ForwardDiff (not public) |
| | `plot` | RecipesBase (not public) |
| | `depwarn` | Base (not public; Julia 1.10 only) |
| `all_explicit_imports_are_public` | `AbstractDynamicalODEProblem`, `AbstractSciMLSolution`, `FunctionArgumentsError`, `NullParameters`, `TooFewArgumentsError`, `TooManyArgumentsError`, `numargs` | SciMLBase (not public) |

`no_implicit_imports`, `no_stale_explicit_imports`, `all_explicit_imports_via_owners`, `all_qualified_accesses_via_owners`: pass, no ignores.

## Aqua

- **stale_deps: FIXED.** `DiffEqCallbacks` was in root `[deps]`/`[compat]` but unused anywhere in `src`/tests; removed. Drops the prior `stale_deps` `@test_broken`.
- **deps_compat:** the prior `@test_broken` is now stale (the check passes); dropped.

## JET

JET still reports 3 genuine errors in `src/plot.jl` (`RecipesBase.plot` has no inferable method for `OrbitPlot`; `DiffEqPhysics.plot`/`plot!` undefined in `plot_orbits`). This is JET-analysis-version dependent: JET 0.11 (the `1` lane) surfaces them; JET 0.9 (the only version installable on the `lts` lane — JET 0.11 needs PrecompileTools floors incompatible with Julia 1.10) does not.

Kept as a **static tracked `@test_broken`** (issue #118) rather than run_qa's version-auto-flagging `jet_broken = true`, which would Unexpected-Pass on `lts` and hard-FAIL on `1`. This preserves master's existing static JET placeholder exactly. JET dropped from the qa env (no longer run there).

## Other

- Removed the orphan `test/explicit_imports.jl` (its two checks, previously run in the Core group, are now part of the QA run_qa six) plus the now-unused root `ExplicitImports` test dep.
- `test/qa/Project.toml`: `SciMLTesting` compat -> `"1.6"`; dropped `JET` and `SafeTestsets` (unused); kept `Aqua` (the ambiguities sub-check needs Aqua a direct dep).

## Verification (local, vs released SciMLTesting 1.6.0; no dev-from-branch)

```
release (Julia 1.12, `1` lane): Quality Assurance | 17 Pass  0 Fail/Error ; JET (broken) | 1 Broken
lts     (Julia 1.10):           Quality Assurance | 17 Pass  0 Fail/Error ; JET (broken) | 1 Broken
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
