### PR TITLE
Document public API: add docstrings + docs entries

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,0 +1,17 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - master
+      - 'release-'
+    tags: '*'
+  pull_request:
+
+jobs:
+  build:
+    uses: "SciML/.github/.github/workflows/documentation.yml@v1"
+    with:
+      coverage: true
+      coverage-directories: "src"
+    secrets: "inherit"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.jl.mem
 Manifest.toml
 .vscode
+docs/build/
+docs/site/

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,8 @@
+[deps]
+DiffEqPhysics = "055956cb-9e8b-5191-98cc-73ae4a59e68a"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+
+[compat]
+Documenter = "1"
+OrdinaryDiffEq = "7"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,23 @@
+using Documenter, DiffEqPhysics
+
+makedocs(
+    sitename = "DiffEqPhysics.jl",
+    authors = "Chris Rackauckas",
+    modules = [DiffEqPhysics],
+    clean = true,
+    doctest = false,
+    linkcheck = false,
+    warnonly = false,
+    format = Documenter.HTML(
+        canonical = "https://docs.sciml.ai/DiffEqPhysics/stable/"
+    ),
+    pages = [
+        "Home" => "index.md",
+        "API" => "api.md"
+    ]
+)
+
+deploydocs(
+    repo = "github.com/SciML/DiffEqPhysics.jl.git";
+    push_preview = true
+)

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,16 @@
+# [API](@id API)
+
+The following functions and types make up the public API of DiffEqPhysics.jl.
+
+## Problem Types
+
+```@docs
+HamiltonianProblem
+```
+
+## Plotting
+
+```@docs
+plot_orbits
+orbitplot
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,75 @@
+# DiffEqPhysics.jl
+
+DiffEqPhysics.jl provides physics-based problem types for the [SciML](https://sciml.ai)
+ecosystem. The main feature is [`HamiltonianProblem`](@ref), which allows you to define and
+solve Hamiltonian systems using automatic differentiation.
+
+For N-body gravitational simulations, please use
+[NBodySimulator.jl](https://github.com/SciML/NBodySimulator.jl).
+
+## Installation
+
+```julia
+using Pkg
+Pkg.add("DiffEqPhysics")
+```
+
+## Quick Start: Simple Pendulum
+
+Define a Hamiltonian system by specifying the Hamiltonian function `H(p, q, params, t)`:
+
+```julia
+using DiffEqPhysics, OrdinaryDiffEq
+
+# Hamiltonian for a simple pendulum: H = p²/(2ml²) + mgl(1 - cos(q))
+function H(p, q, params, t)
+    g, m, l = params
+    return p^2 / (2 * m * l^2) + m * g * l * (1 - cos(q))
+end
+
+# Parameters: gravitational acceleration, mass, length
+params = (9.81, 1.0, 1.0)
+
+# Initial conditions: momentum p₀ and angle q₀
+p₀ = 0.0
+q₀ = π / 4  # 45 degrees
+
+# Create and solve the Hamiltonian problem
+prob = HamiltonianProblem(H, p₀, q₀, (0.0, 10.0), params)
+sol = solve(prob, SofSpa10(), dt = 0.01)
+```
+
+The equations of motion `q̇ = ∂H/∂p` and `ṗ = -∂H/∂q` are automatically computed using
+ForwardDiff.jl.
+
+## Features
+
+  - **Automatic differentiation**: Derivatives are computed automatically from the
+    Hamiltonian function.
+  - **Multiple input types**: Works with scalars, `StaticArrays`, or regular
+    `AbstractArray`s.
+  - **Symplectic solvers**: Use symplectic integrators from OrdinaryDiffEq.jl (like
+    `SofSpa10`) to preserve the Hamiltonian structure.
+  - **Manual derivatives**: Optionally provide your own derivative functions `(dp, dq)` for
+    better performance.
+
+## Providing Manual Derivatives
+
+For better performance, you can provide the derivative functions directly:
+
+```julia
+# dp = -∂H/∂q, dq = ∂H/∂p
+dp(p, q, params, t) = -params[1] * params[2] * params[3] * sin(q)  # -mgl*sin(q)
+dq(p, q, params, t) = p / (params[2] * params[3]^2)                # p/(ml²)
+
+prob = HamiltonianProblem((dp, dq), p₀, q₀, (0.0, 10.0), params)
+```
+
+## Plotting Orbits
+
+For solutions of N-body-style problems, [`plot_orbits`](@ref) and [`orbitplot`](@ref) draw
+the trajectory of each body.
+
+## Public API
+
+See the [API](@ref API) page for the full list of documented public functions and types.

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -1,6 +1,4 @@
-"""
-Internal type for orbit plotting recipe.
-"""
+# Internal type for the orbit plotting recipe.
 struct OrbitPlot
     sol::Any
     body_names::Any


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## Summary

DiffEqPhysics.jl had no rendered Documenter site at all, so its public API had docstrings in source but no rendered-docs entries. This PR adds a minimal Documenter setup and wires every public name into an `@docs` block.

The public/exported names (verified by loading the package: `intersect(names(DiffEqPhysics), ...)`):

- `HamiltonianProblem` — already had a docstring; now has a rendered `@docs` entry.
- `plot_orbits` — already had a docstring; now has a rendered `@docs` entry.
- `orbitplot` — already had a docstring; now has a rendered `@docs` entry.

All three had docstrings in the source but were not surfaced in any rendered documentation (there was no `docs/` directory).

## Changes

- `docs/make.jl`, `docs/Project.toml`: minimal Documenter build (`modules = [DiffEqPhysics]`, `warnonly = false`).
- `docs/src/index.md`: Home page (installation + quick-start pendulum example, adapted from the README).
- `docs/src/api.md`: API reference page with `@docs` blocks for `HamiltonianProblem`, `plot_orbits`, and `orbitplot`.
- `.github/workflows/Documentation.yml`: centralized SciML `documentation.yml@v1` caller so the site builds and deploys in CI.
- `src/plot.jl`: the internal (non-public) `OrbitPlot` recipe type carried a stray one-line docstring; converted to a plain comment so Documenter's `missing_docs` check (now active because `modules = [DiffEqPhysics]`) does not require an internal type to be documented in the public manual.
- `.gitignore`: ignore `docs/build/`.

## Validation

Built the docs locally with `warnonly = false` (so Documenter errors on any missing docstring / unresolved `@ref`):

```
[ Info: CrossReferences: building cross-references.
[ Info: CheckDocument: running document checks.
[ Info: Populate: populating indices.
[ Info: RenderDocument: rendering document.
[ Info: HTMLWriter: rendering HTML pages.
```

No `missing_docs` or `cross_references` errors. The rendered `docs/build/api/index.html` contains docstring anchors `id="DiffEqPhysics.HamiltonianProblem"`, `id="DiffEqPhysics.plot_orbits"`, and `id="DiffEqPhysics.orbitplot"`. (The only remaining output is Documenter's "could not auto-detect the building environment. Skipping deployment" notice, which is `deploydocs` correctly no-op-ing outside CI.)

Runic check passes on the changed source (`src/plot.jl`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)