### PR TITLE
Bump version to 3.19.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DiffEqPhysics"
 uuid = "055956cb-9e8b-5191-98cc-73ae4a59e68a"
-version = "3.19.0"
+version = "3.19.1"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (3.19.0 -> 3.19.1) to release unreleased commits on `master` via JuliaRegistrator.