### PR TITLE
Release prep: bump DiffEqPhysics to 3.19.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DiffEqPhysics"
 uuid = "055956cb-9e8b-5191-98cc-73ae4a59e68a"
-version = "3.19.1"
+version = "3.19.2"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
Patch release for accumulated docstring/QA/test-scaffolding changes since 3.19.1 (no functional/API changes).